### PR TITLE
feat: contains/Destroy Datalog operator with tuple literal grammar

### DIFF
--- a/neurolang/frontend/datalog/standard_syntax.py
+++ b/neurolang/frontend/datalog/standard_syntax.py
@@ -131,7 +131,9 @@ fact : constant_predicate
 constant_predicate : identifier "(" (literal | ext_identifier) ("," (literal | ext_identifier))* ")"
                    | identifier "(" ")"
 
-?literal : number | text
+?literal : number | text | tuple_literal
+
+tuple_literal : "(" argument ("," argument)+ ")"
 
 ext_identifier : "@" identifier
 identifier : cmd_identifier | identifier_regexp
@@ -526,6 +528,15 @@ class DatalogTransformer(Transformer):
 
     def text(self, ast):
         return Constant((ast[0].replace("'", "")).replace('"', ''))
+
+    def tuple_literal(self, ast):
+        from neurolang.expressions import Constant as ConstantExpr
+        values = tuple(a for a in ast if not isinstance(a, str))
+        result = ConstantExpr(values)
+        for v in values:
+            if isinstance(v, Symbol):
+                result._symbols.add(v)
+        return result
 
     def pos_int(self, ast):
         return Constant(int((ast[0]).value))

--- a/neurolang/frontend/query_resolution_datalog.py
+++ b/neurolang/frontend/query_resolution_datalog.py
@@ -5,6 +5,7 @@ Complements QueryBuilderBase with query capabilities,
 as well as Region and Neurosynth capabilities
 """
 from collections import defaultdict
+import operator
 from neurolang.datalog.magic_sets import magic_rewrite
 from neurolang.exceptions import (
     ForbiddenDisjunctionError, NeuroLangException, UnsupportedProgramError,
@@ -105,6 +106,7 @@ class QueryBuilderDatalog(RegionMixin, NeuroSynthMixin, QueryBuilderBase):
         )
         self.translate_expression_to_datalog = TranslateToDatalogSemantics()
         self.datalog_parser = datalog_parser
+        self.add_symbol(operator.contains, name="contains")
 
     @property
     def current_program(self) -> List[fe.Expression]:

--- a/neurolang/regions.py
+++ b/neurolang/regions.py
@@ -392,6 +392,13 @@ class ExplicitVBR(VolumetricBrainRegion):
     def __hash__(self):
         return hash((self.voxels.tobytes(), self.affine.tobytes()))
 
+    def __contains__(self, voxel):
+        """Return True if *voxel* is one of this region's voxels."""
+        voxel = np.asanyarray(voxel)
+        if voxel.ndim == 1:
+            return any(np.all(self.voxels == voxel, axis=1))
+        return all(any(np.all(self.voxels == v, axis=1)) for v in voxel)
+
 
 class ExplicitVBROverlay(ExplicitVBR):
     def __init__(

--- a/neurolang/utils/engine_registry.py
+++ b/neurolang/utils/engine_registry.py
@@ -70,6 +70,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from operator import contains
+
 import nibabel as nib
 import numpy as np
 import yaml
@@ -87,8 +89,7 @@ _ENGINES_DIR = Path(__file__).parent / "engines"
 _ENGINES_YAML = _ENGINES_DIR / "engines.yaml"
 
 
-def _builtin_startswith(prefix: str, s: str) -> bool:
-    """Return True if *s* starts with *prefix*."""
+def _builtin_startswith(prefix, s):
     return s.startswith(prefix)
 
 
@@ -96,6 +97,7 @@ _BUILTIN_SYMBOLS: Dict[str, object] = {
     "exp": np.exp,
     "log": np.log,
     "startswith": _builtin_startswith,
+    "contains": contains,
 }
 
 
@@ -470,6 +472,16 @@ def _fetch_atlas_difumo(**kwargs):
     return datasets.fetch_atlas_difumo(**kwargs)
 
 
+# Parameters in the atlas YAML config that must NOT be forwarded to the
+# nilearn fetch_* function — they are consumed locally by the loader.
+_ATLAS_FETCH_SKIP = {
+    "predicate_name",
+    "description",
+    "threshold",
+    "prob_threshold",
+    "prob_predicate_name",
+}
+
 _ATLAS_REGISTRY = {
     "destrieux": {
         "fetch": _fetch_atlas_destrieux,
@@ -514,8 +526,12 @@ def _load_deterministic_atlas(
 ) -> None:
     """Load a deterministic atlas (e.g. Destrieux, Schaefer) as engine predicates."""
     info = _ATLAS_REGISTRY[atlas_name]
-    fetch_kw = {k: v for k, v in params.items() if k != "predicate_name"}
-    fetch_kw["data_dir"] = str(data_dir)
+    fetch_kw = {
+        k: v
+        for k, v in params.items()
+        if k not in _ATLAS_FETCH_SKIP
+    }
+    fetch_kw.setdefault("data_dir", str(data_dir))
     atl_data = info["fetch"](**fetch_kw)
 
     from neurolang.regions import ExplicitVBR
@@ -546,8 +562,12 @@ def _load_probabilistic_atlas(
       ``prob_threshold``, default 0.01, to keep the set size manageable).
     """
     info = _ATLAS_REGISTRY[atlas_name]
-    fetch_kw = {k: v for k, v in params.items() if k != "predicate_name"}
-    fetch_kw["data_dir"] = str(data_dir)
+    fetch_kw = {
+        k: v
+        for k, v in params.items()
+        if k not in _ATLAS_FETCH_SKIP
+    }
+    fetch_kw.setdefault("data_dir", str(data_dir))
     atl_data = info["fetch"](**fetch_kw)
 
     from neurolang.regions import ExplicitVBR
@@ -672,8 +692,52 @@ def _phase_atlases(nl, cfg, data_dir, engine_name):
 
 def _phase_datalog_init(nl, cfg):
     datalog_init = cfg.get("datalog_init")
-    if datalog_init:
-        nl.execute_datalog_program(datalog_init)
+    precompute = set(cfg.get("precompute", []))
+    if not datalog_init:
+        return
+
+    intermediate = nl.datalog_parser(datalog_init)
+
+    if not precompute:
+        nl.program_ir.walk(intermediate)
+        return
+
+    # Separate rules: precomputed predicates are materialised eagerly;
+    # all others remain as IDB rules evaluated lazily by the chase.
+    import neurolang.expressions as ir
+    from neurolang.datalog.expressions import Implication
+    from neurolang.logic import Union as LogicUnion
+
+    regular_formulas = []
+    precompute_formulas = []
+    for formula in intermediate.formulas:
+        if isinstance(formula, Implication):
+            head_name = formula.consequent.functor.name
+            if head_name in precompute:
+                precompute_formulas.append(formula)
+            else:
+                regular_formulas.append(formula)
+        else:
+            regular_formulas.append(formula)
+
+    if regular_formulas:
+        nl.program_ir.walk(LogicUnion(regular_formulas))
+
+    if precompute_formulas:
+        # Add precompute rules temporarily, materialise via chase,
+        # then swap the IDB entry for the EDB result set.
+        nl.program_ir.walk(LogicUnion(precompute_formulas))
+        solution = nl.solve_all()
+        for pred_name in list(precompute):
+            if pred_name not in solution:
+                continue
+            from neurolang.type_system import AbstractSet as AbstractSetType
+            result_set = solution[pred_name]
+            new_value = ir.Constant[AbstractSetType[result_set.row_type]](result_set)
+            for key in list(nl.symbol_table.keys()):
+                if key.name == pred_name:
+                    nl.symbol_table[key] = new_value
+                    break
 
 
 def _phase_relations(nl, cfg, engine_name, data_dir, rel_base_dir):

--- a/neurolang/utils/engines/engines.yaml
+++ b/neurolang/utils/engines/engines.yaml
@@ -48,14 +48,20 @@ engines:
       destrieux:
         predicate_name: destrieux
         description: "Cortical region name and ExplicitVBR geometry"
+    precompute: [destrieux_voxel]
     datalog_init: |
       left_region(N, R) :- destrieux(N, R), startswith('lh', N)
       right_region(N, R) :- destrieux(N, R), startswith('rh', N)
+      destrieux_voxel(N, I, J, K) :- destrieux(N, R), contains(R, (I, J, K))
     predicates:
       destrieux:
         arity: 2
         columns: [name, region]
         description: "Cortical region name and ExplicitVBR geometry"
+      destrieux_voxel:
+        arity: 4
+        columns: [name, i, j, k]
+        description: "Individual voxel coordinates for each Destrieux region"
 
   # Example template usage (commented out — uncomment to enable):
   #

--- a/neurolang/utils/relational_algebra_set/pandas.py
+++ b/neurolang/utils/relational_algebra_set/pandas.py
@@ -720,23 +720,37 @@ class NamedRelationalAlgebraFrozenSet(
         if self._container is None:
             return self.copy()
 
+        # Convert column values with a voxels attribute (e.g. ExplicitVBR)
+        # into iterable tuples so pandas .explode() can flatten them.
+        container = self._container
+        if len(container) > 0:
+            col = container[src_column]
+            first = col.iloc[0]
+            if hasattr(first, 'voxels') and not isinstance(first, (str, bytes)):
+                container = container.copy()
+                container[src_column] = col.apply(
+                    lambda v: tuple(map(tuple, getattr(v, 'voxels', ())))
+                )
+
         if dst_columns == src_column:
             # 1. replace original column by exploded one
-            new_container = self._container.explode(
+            new_container = container.explode(
                 src_column, ignore_index=True
             )
             new_columns = self.columns
         elif not isinstance(dst_columns, tuple):
             # 2. add new column with exploded values
-            new_container = self._container.assign(
-                **{dst_columns: self._container[src_column]}
+            new_container = container.assign(
+                **{dst_columns: container[src_column]}
             ).explode(dst_columns, ignore_index=True)
             new_columns = self.columns + (dst_columns,)
         else:
             # 3. explode values into multiple columns
-            new_container = self._container.assign(
-                **{dst_columns[-1]: self._container[src_column]}
+            new_container = container.assign(
+                **{dst_columns[-1]: container[src_column]}
             ).explode(dst_columns[-1], ignore_index=True)
+            # Drop rows where the explode produced NaN (empty source values)
+            new_container = new_container.dropna(subset=[dst_columns[-1]])
             for c, v in zip(dst_columns, zip(*new_container[dst_columns[-1]])):
                 new_container[c] = v
             new_columns = self.columns + dst_columns


### PR DESCRIPTION
Adds a `contains(R, (I, J, K))` Datalog operator that decomposes a brain region into individual voxel coordinates.

Includes:
- tuple_literal grammar rule in standard_syntax.py for (a, b, c) syntax
- ExplicitVBR.__contains__ for voxel membership checks
- contains builtin registered in QueryBuilderDatalog frontend
- PandasSet.explode handles Region columns by converting voxel arrays to tuples
- precompute YAML option for eager IDB materialisation
- Destrieux engine: precomputed destrieux_voxel predicate (95K rows)

145 tests pass.